### PR TITLE
Enable customer/agent to reset password from single route

### DIFF
--- a/Fixtures/AutomationWorkflowFixtures.php
+++ b/Fixtures/AutomationWorkflowFixtures.php
@@ -72,6 +72,15 @@ class AutomationWorkflowFixtures extends DoctrineFixture
             'sort_order' => '5',
             'events' => ['uvdesk.ticket.customer_reply']
         ],
+        [
+            'name' => 'Forgot Password',
+            'description' => 'Send customer an email on forgot password action.',
+            'conditions' => 'N;',
+            'actions' => 'a:1:{i:1;a:2:{s:4:"type";s:21:"uvdesk.user.mail_user";s:5:"value";s:2:"10";}}',
+            'status' => '1',
+            'sort_order' => '2',
+            'events' => ['uvdesk.user.forgot_password']
+        ],
     ];
 
     public function load(ObjectManager $entityManager)

--- a/Fixtures/AutomationWorkflowFixtures.php
+++ b/Fixtures/AutomationWorkflowFixtures.php
@@ -13,7 +13,7 @@ class AutomationWorkflowFixtures extends DoctrineFixture
             'name' => 'Customer Created',
             'description' => 'Send customer a welcome email after their account has been created.',
             'conditions' => 'N;',
-            'actions' => 'a:1:{i:2;a:2:{s:4:"type";s:29:"uvdesk.customer.mail_customer";s:5:"value";s:1:"8";}}',
+            'actions' => 'a:1:{i:2;a:2:{s:4:"type";s:29:"uvdesk.customer.mail_customer";s:5:"value";s:1:"7";}}',
             'status' => '1',
             'sort_order' => '1',
             'events' => ['uvdesk.customer.created']
@@ -28,28 +28,10 @@ class AutomationWorkflowFixtures extends DoctrineFixture
             'events' => ['uvdesk.agent.created']
         ],
         [
-            'name' => 'Customer Forgot Password',
-            'description' => 'Send customer an email on forgot password action.',
-            'conditions' => 'N;',
-            'actions' => 'a:1:{i:1;a:2:{s:4:"type";s:29:"uvdesk.customer.mail_customer";s:5:"value";s:1:"9";}}',
-            'status' => '1',
-            'sort_order' => '2',
-            'events' => ['uvdesk.customer.forgot_password']
-        ],
-        [
-            'name' => 'Agent Forgot Password',
-            'description' => 'Send agent an email to reset password',
-            'conditions' => 'N;',
-            'actions' => 'a:1:{i:1;a:2:{s:4:"type";s:23:"uvdesk.agent.mail_agent";s:5:"value";s:1:"4";}}',
-            'status' => '1',
-            'sort_order' => '3',
-            'events' => ['uvdesk.agent.forgot_password']
-        ],
-        [
             'name' => 'Ticket Created',
             'description' => 'Automate actions when ticket is created.',
             'conditions' => 'N;',
-            'actions' => 'a:3:{i:0;a:2:{s:4:"type";s:27:"uvdesk.ticket.mail_customer";s:5:"value";s:1:"7";}i:1;a:2:{s:4:"type";s:26:"uvdesk.ticket.assign_agent";s:5:"value";s:18:"responsePerforming";}i:2;a:2:{s:4:"type";s:24:"uvdesk.ticket.mail_agent";s:5:"value";a:2:{s:3:"for";a:1:{i:0;s:13:"assignedAgent";}s:5:"value";s:1:"2";}}}',
+            'actions' => 'a:3:{i:0;a:2:{s:4:"type";s:27:"uvdesk.ticket.mail_customer";s:5:"value";s:1:"6";}i:1;a:2:{s:4:"type";s:26:"uvdesk.ticket.assign_agent";s:5:"value";s:18:"responsePerforming";}i:2;a:2:{s:4:"type";s:24:"uvdesk.ticket.mail_agent";s:5:"value";a:2:{s:3:"for";a:1:{i:0;s:13:"assignedAgent";}s:5:"value";s:1:"2";}}}',
             'status' => '1',
             'sort_order' => '5',
             'events' => ['uvdesk.ticket.created']
@@ -67,7 +49,7 @@ class AutomationWorkflowFixtures extends DoctrineFixture
             'name' => 'Customer Replied on Ticket',
             'description' => 'Send agent an email when reply is added on ticket.',
             'conditions' => 'N;',
-            'actions' => 'a:1:{i:1;a:2:{s:4:"type";s:24:"uvdesk.ticket.mail_agent";s:5:"value";a:2:{s:3:"for";a:1:{i:0;s:13:"assignedAgent";}s:5:"value";s:1:"6";}}}',
+            'actions' => 'a:1:{i:1;a:2:{s:4:"type";s:24:"uvdesk.ticket.mail_agent";s:5:"value";a:2:{s:3:"for";a:1:{i:0;s:13:"assignedAgent";}s:5:"value";s:1:"5";}}}',
             'status' => '1',
             'sort_order' => '5',
             'events' => ['uvdesk.ticket.customer_reply']
@@ -76,7 +58,7 @@ class AutomationWorkflowFixtures extends DoctrineFixture
             'name' => 'Forgot Password',
             'description' => 'Send customer an email on forgot password action.',
             'conditions' => 'N;',
-            'actions' => 'a:1:{i:1;a:2:{s:4:"type";s:21:"uvdesk.user.mail_user";s:5:"value";s:2:"10";}}',
+            'actions' => 'a:1:{i:1;a:2:{s:4:"type";s:21:"uvdesk.user.mail_user";s:5:"value";s:1:"8";}}',
             'status' => '1',
             'sort_order' => '2',
             'events' => ['uvdesk.user.forgot_password']

--- a/Workflow/FunctionalGroup.php
+++ b/Workflow/FunctionalGroup.php
@@ -9,4 +9,5 @@ abstract class FunctionalGroup
     const AGENT = 'agent';
     const TICKET = 'ticket';
     const CUSTOMER = 'customer';
+    const USER = 'user';
 }


### PR DESCRIPTION
**Issue** #24
**Enable customer/agent to reset password from single route**
- Added a new forgot password Workflow seed entry in AutomationWorkflowFixtures.php
- Removed old Customer/Agent forgot password Workflow seed entries from AutomationWorkflowFixtures.php
- Added a new functional group _user_ in FunctionalGroup.php